### PR TITLE
Handle optional Google API and date deps

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -27,7 +27,30 @@ from num2words import num2words
 
 import json
 import math
-from babel.dates import format_date
+# `babel` é utilizado apenas para formatar datas em português. Como esse
+# pacote pode não estar disponível em todos os ambientes (por exemplo, nos
+# testes automatizados), tentamos importá-lo de forma opcional e provemos um
+# fallback simples caso a importação falhe.
+try:  # pragma: no cover - comportamento dependente de ambiente
+    from babel.dates import format_date as babel_format_date
+except ModuleNotFoundError:  # pragma: no cover
+    babel_format_date = None
+
+
+def format_date(value, format="d 'de' MMMM 'de' yyyy", locale="pt_BR"):
+    """Formata a data em português.
+
+    Se `babel` não estiver instalado, realiza uma formatação manual.
+    """
+    if babel_format_date:
+        return babel_format_date(value, format=format, locale=locale)
+
+    # Fallback manual com nomes de meses em português
+    months = [
+        "janeiro", "fevereiro", "março", "abril", "maio", "junho",
+        "julho", "agosto", "setembro", "outubro", "novembro", "dezembro",
+    ]
+    return f"{value.day:02d} de {months[value.month-1]} de {value.year}"
 
 
 from core.services.calculos_service import calcular_valor_diarias, calcular_valor_deslocamento, CalculoServiceError

--- a/backend/core/services/google_drive_service.py
+++ b/backend/core/services/google_drive_service.py
@@ -2,11 +2,22 @@
 
 import io
 import logging
-from googleapiclient.discovery import build
-from googleapiclient.http import MediaIoBaseUpload
-from googleapiclient.errors import HttpError
-from google.oauth2 import service_account
 from django.conf import settings
+
+# Importações do Google API são opcionais para evitar falhas quando o
+# pacote `google-api-python-client` não está instalado. Isso permite que
+# módulos que não utilizam o Google Drive sejam carregados sem erro.
+try:  # pragma: no cover - comportamento dependente de ambiente
+    from googleapiclient.discovery import build
+    from googleapiclient.http import MediaIoBaseUpload
+    from googleapiclient.errors import HttpError
+    from google.oauth2 import service_account
+except ModuleNotFoundError:  # pragma: no cover - executado apenas quando pacote ausente
+    build = MediaIoBaseUpload = service_account = None
+
+    class HttpError(Exception):
+        """Fallback simples quando googleapiclient não está disponível."""
+        pass
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +28,16 @@ SCOPES = [
 ]
 
 def _get_drive_service():
+    if build is None or service_account is None:
+        raise ModuleNotFoundError(
+            "google-api-python-client não está instalado. "
+            "Instale a dependência para utilizar o Google Drive."
+        )
+
     sa_file = getattr(settings, "GOOGLE_SERVICE_ACCOUNT_FILE", None)
     if not sa_file:
         raise RuntimeError("GOOGLE_SERVICE_ACCOUNT_FILE não configurado em settings.")
+
     creds = service_account.Credentials.from_service_account_file(sa_file, scopes=SCOPES)
     return build("drive", "v3", credentials=creds, cache_discovery=False)
 


### PR DESCRIPTION
## Summary
- avoid crashing when google-api-python-client is missing by lazy imports and fallbacks
- add manual PT-BR date formatter when Babel isn't installed

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e71fbb74832aaebc90c51d1b9497